### PR TITLE
cmd handler doc

### DIFF
--- a/src/cmdhandler/command_handler.cpp
+++ b/src/cmdhandler/command_handler.cpp
@@ -2,8 +2,22 @@
 // Created by tim on 2/27/21.
 //
 
-//---no return response should have any new line characters at the start or end
-
+/**
+ * This 'command handler' breaks things up into 'target systems'.
+ *
+ * Each target system returns a string that is the server's response
+ * to the given command (these responses are sent/logged in the session class, do_read function).
+ *
+ * Each target system has a set (or one, or none) of state variables it modifies/reads.
+ * For example:
+ *      The 'robot' target system handles the 'robot' state variable
+ * Another example:
+ *      The 'state' target system doesn't have any state variables it modifies/reads.
+ *      This is because it simply saves/loads states into/out of memory.
+ *
+ *  NOTE:
+ *      No return responses should have any new line characters at the start/end.
+ */
 #include "command_handler.h"
 
 //these commands require a target system to be given alongside them
@@ -11,6 +25,13 @@ std::string target_commands[] = {"set", "get", "delete", "list", "save", "load"}
 
 const std::string SAVE_STATE_DIR = "states/";
 
+/**
+ * Do a command by calling a specific target system depending on user command string.
+ *
+ * @param tokens tokenized vector version of user command
+ * @param current_state server's current state struct
+ * @return response to user command as string
+ */
 std::string command_handler::do_command(const std::vector<std::string>& tokens, StateVariables& current_state){
     std::string command = tokens[0];
 
@@ -41,7 +62,14 @@ std::string command_handler::do_command(const std::vector<std::string>& tokens, 
     }
 }
 
-std::vector<std::string> command_handler::tokenize_values(const std::string& values){
+/**
+ * Tokenize (split) a value string by commas. <br>
+ * Used for when a target system takes a value parameter as a comma separated list.
+ *
+ * @param values value string to tokenize
+ * @return a vector of strings
+ */
+std::vector<std::string> command_handler::tokenize_values_by_commas(const std::string& values){
     std::vector<std::string> tokens;
 
     std::string delimiter = ",";
@@ -57,6 +85,15 @@ std::vector<std::string> command_handler::tokenize_values(const std::string& val
     return tokens;
 }
 
+/**
+ * Modifies the 'robots' state variable. <br>
+ * A robot has a name and a collection of 4 marker int ids. <br>
+ * system functions: set, get, list, and delete robots
+ *
+ * @param tokens tokenized vector version of user command
+ * @param current_state server's current state struct
+ * @return response to user command as string
+ */
 std::string command_handler::robot_system(const std::vector<std::string>& tokens, StateVariables& current_state){
     if(tokens[0] == "list"){
         std::string response = "Current robots:";
@@ -75,7 +112,7 @@ std::string command_handler::robot_system(const std::vector<std::string>& tokens
 
         std::string robot_id = tokens[2];
         //tokenize by commas
-        std::vector<std::string> values = tokenize_values(tokens[3]);
+        std::vector<std::string> values = tokenize_values_by_commas(tokens[3]);
         //convert string values to ints
         std::vector<int> values_as_int;
         for(int i = 0; i < values.size(); i++){
@@ -128,6 +165,13 @@ std::string command_handler::robot_system(const std::vector<std::string>& tokens
     }
 }
 
+/**
+ * Saves and loads current state configurations to binary files in the 'states/' directory
+ *
+ * @param tokens tokenized vector version of user command
+ * @param current_state server's current state struct
+ * @return response to user command as string
+ */
 std::string command_handler::state_system(const std::vector<std::string>& tokens, StateVariables& current_state){
     if(!std::filesystem::exists(SAVE_STATE_DIR)){
         std::error_code ec;
@@ -234,6 +278,15 @@ std::string command_handler::state_system(const std::vector<std::string>& tokens
     }
 }
 
+/**
+ * Modifies the 'collectors' state variable. <br>
+ * A collector has a name and an ip address associated with it, collectors receive data via udp from camera. <br>
+ * system functions: set, get, list, and delete collectors
+ *
+ * @param tokens tokenized vector version of user command
+ * @param current_state server's current state struct
+ * @return response to user command as string
+ */
 std::string command_handler::collector_system(const std::vector<std::string>& tokens, StateVariables& current_state) {
     if(tokens[0] == "list"){
         std::string response = "Current collectors:";
@@ -294,6 +347,11 @@ std::string command_handler::collector_system(const std::vector<std::string>& to
     }
 }
 
+/**
+ * Display available target systems/commands to user
+ *
+ * @return help string
+ */
 std::string command_handler::help_command(){
     std::string response = "current target systems:\n";
     response += "    robot, state, collector\n\n";

--- a/src/cmdhandler/command_handler.h
+++ b/src/cmdhandler/command_handler.h
@@ -21,7 +21,7 @@ private:
     static std::string state_system(const std::vector<std::string>& tokens, StateVariables& current_state);
     static std::string collector_system(const std::vector<std::string>& tokens, StateVariables& current_state);
     static std::string help_command();
-    static std::vector<std::string> tokenize_values(const std::string& values);
+    static std::vector<std::string> tokenize_values_by_commas(const std::string& values);
 };
 
 

--- a/src/cmdhandler/server.cpp
+++ b/src/cmdhandler/server.cpp
@@ -5,6 +5,10 @@ server::server(asio::io_context& io_context, short port, std::shared_ptr<GlobalS
     do_accept();
 }
 
+/**
+ * Accept a new connection and make a shared pointer to a session instance. <br>
+ * Then start the session and start reading/writing from/to tcp stream
+ */
 void server::do_accept()
 {
     acceptor_.async_accept([this](asio::error_code ec, tcp::socket socket){

--- a/src/cmdhandler/session.cpp
+++ b/src/cmdhandler/session.cpp
@@ -7,6 +7,13 @@ session::session(tcp::socket socket, std::shared_ptr<GlobalState> state): socket
 
 }
 
+/**
+ * Read tcp stream until a new line character is present to build a command string
+ *
+ * @param data tcp stream to read
+ * @param length length of data param
+ * @return command obtained from user as a string
+ */
 std::string session::get_command(char data[], std::size_t length){
     std::string current_command;
     for (int i = 0; i < length; i++) {
@@ -21,7 +28,13 @@ std::string session::get_command(char data[], std::size_t length){
     return current_command;
 }
 
-std::vector<std::string> session::tokenize_command(std::string command){
+/**
+ * Tokenize (split) a command string by spaces
+ *
+ * @param command string to tokenize
+ * @return a vector of strings
+ */
+std::vector<std::string> session::tokenize_command_by_spaces(std::string command){
     std::vector<std::string> tokens;
 
     std::string delimiter = " ";
@@ -37,6 +50,10 @@ std::vector<std::string> session::tokenize_command(std::string command){
     return tokens;
 }
 
+/**
+ * Initialize a new connection. <br>
+ * Will write out command prompt character and begin reading from connection.
+ */
 void session::start()
 {
     spdlog::info(socket_.remote_endpoint().address().to_string()+" connected");
@@ -44,6 +61,10 @@ void session::start()
     do_read();
 }
 
+/**
+ * Wait for and then read data from a connection (session) instance. <br>
+ * Also return command handler's response to user.
+ */
 void session::do_read()
 {
         auto self(shared_from_this());
@@ -66,7 +87,7 @@ void session::do_read()
                                             spdlog::info(socket_.remote_endpoint().address().to_string()+": "+command);
 
                                             //if not 'quit', tokenize input by " "
-                                            std::vector<std::string> tokens = tokenize_command(command);
+                                            std::vector<std::string> tokens = tokenize_command_by_spaces(command);
 
                                             StateVariables local_variables = m_state->get_state();
                                             //TODO: pass to some input/token handler class
@@ -85,6 +106,12 @@ void session::do_read()
 
 }
 
+/**
+ *  Write out to a connection (session) instance
+ *
+ * @param msg message string to write out
+ * @param length length of msg param
+ */
 void session::do_write(std::string msg, std::size_t length)
 {
     auto self(shared_from_this());

--- a/src/cmdhandler/session.h
+++ b/src/cmdhandler/session.h
@@ -19,7 +19,7 @@ public:
     void start();
 private:
     std::string get_command(char data[], std::size_t length);
-    std::vector<std::string> tokenize_command(std::string command);
+    std::vector<std::string> tokenize_command_by_spaces(std::string command);
 
     void do_read();
 


### PR DESCRIPTION
related to #11 

- add documentation blocks for functions in `command_handler`, `session`, and `server` classes
- rename the `tokenize___` functions to be more descriptive (ex: `tokenize_values_by_commas`)