### PR TITLE
refactor/stateProto

### DIFF
--- a/src/cmdhandler/state.proto
+++ b/src/cmdhandler/state.proto
@@ -1,21 +1,38 @@
 syntax = "proto3";
 
-message MarkerIds{
+message MarkerIds
+{
   repeated int32 ids = 1;
 }
+
+message RobotSys
+{
+  map<string, MarkerIds> robots = 1;
+}
+
 message Endpoint
 {
   string address = 1;
   int32 port = 2;
 }
 
-message State {
-  map<string, MarkerIds> robots = 1;
-  map<string, Endpoint> collectors = 2;
+message CollectorSys
+{
+  map<string, Endpoint> collectors = 1;
+}
 
-  string url = 3;
-  repeated double camera_matrix = 4;
-  repeated double distortion_matrix = 5;
-  int32 marker_dictionary = 6;
-  map<string, bool> options = 7;
+message CameraSys
+{
+  string url = 1;
+  repeated double camera_matrix = 2;
+  repeated double distortion_matrix = 3;
+  int32 marker_dictionary = 4;
+  map<string, bool> options = 5;
+}
+
+message State
+{
+  RobotSys robot_system = 1;
+  CollectorSys collector_system = 2;
+  CameraSys camera_system = 3;
 }


### PR DESCRIPTION
closes #21 

- ***!!any previously saved state will not load with this PR's changes!!***
- uses a `message` for each target system
- had to use `_____Sys` instead of `_____System` naming convention because of naming conflicts with the structs used in the `Variables` class