### PR TITLE
Fix memory issue in session class

### DIFF
--- a/src/cmdhandler/session.cpp
+++ b/src/cmdhandler/session.cpp
@@ -135,7 +135,7 @@ void session::do_write(std::string msg, std::size_t length)
                                   }
 
                                   if(!pmsg->empty())
-                                      spdlog::info(socket_.remote_endpoint().address().to_string()+" >> \n{}", *pmsg);
+                                      spdlog::info("{} >> \n{}", socket_.remote_endpoint().address().to_string(), *pmsg);
                               }
 
                               // Wait for more input

--- a/src/cmdhandler/session.cpp
+++ b/src/cmdhandler/session.cpp
@@ -57,8 +57,9 @@ std::vector<std::string> session::tokenize_command_by_spaces(std::string command
 void session::start()
 {
     spdlog::info(socket_.remote_endpoint().address().to_string()+" connected");
+    // Write out an initial '>' character so that user input stands out
+    // do_write() also runs do_read(), so the program will begin listening after this is sent
     do_write("> ", 2);
-    do_read();
 }
 
 /**
@@ -74,31 +75,30 @@ void session::do_read()
                                     if (!ec) {
                                         //get command from data stream
                                         std::string command = get_command(data_, length);
+                                        // Log input from user
+                                        spdlog::info(socket_.remote_endpoint().address().to_string()+": "+command);
+                                        // Output stream
+                                        std::stringstream output;
 
                                         if(command == "quit"){
                                             spdlog::info(socket_.remote_endpoint().address().to_string()+" disconnected");
                                             socket_.close();
                                         }else if(command == "clear"){
-                                            spdlog::info(socket_.remote_endpoint().address().to_string()+": "+command);
                                             std::string clear_string = "\033[2J\033[H";
-                                            do_write(clear_string, clear_string.size());
+                                            output << clear_string;
                                         }else {
-                                            //log input from user
-                                            spdlog::info(socket_.remote_endpoint().address().to_string()+": "+command);
-
                                             //if not 'quit', tokenize input by " "
                                             std::vector<std::string> tokens = tokenize_command_by_spaces(command);
 
                                             StateVariables local_variables = m_state->get_state();
-                                            //TODO: pass to some input/token handler class
                                             std::string response = command_handler::do_command(tokens, local_variables);
                                             m_state->receive(local_variables);
 
-                                            //log/write response
-                                            spdlog::info(socket_.remote_endpoint().address().to_string()+" >> \n"+response);
-                                            do_write(response+"\n", response.length()+2);
+                                            output << response << "\n";
                                         }
-                                        do_write("> ", 2);
+                                        output << "> ";
+                                        // Send the response
+                                        do_write(output.str(), output.str().length());
                                     }else if(ec == asio::error::eof || ec == asio::error::connection_reset){
                                         spdlog::info(socket_.remote_endpoint().address().to_string()+" disconnected");
                                     }
@@ -115,11 +115,30 @@ void session::do_read()
 void session::do_write(std::string msg, std::size_t length)
 {
     auto self(shared_from_this());
-    asio::async_write(socket_, asio::buffer(msg, length),
-                      [this, self](asio::error_code ec, std::size_t length)
+    std::shared_ptr<std::string> pmsg = std::make_shared<std::string>(msg);
+    asio::async_write(socket_, asio::buffer(pmsg->data(), length),
+                      [this, self, pmsg](asio::error_code ec, std::size_t length)
                       {
                           if (!ec)
                           {
+                              // Log what was sent to user
+                              if(*pmsg != "> ")
+                              {
+                                  size_t pos;
+                                  // If end of message is "\n> ", remove it before logging
+                                  if((pos = pmsg->find("\n> ")) != std::string::npos){
+                                      pmsg->erase(pos, 3);
+                                  }
+                                  // If end of message is "> ", remove it before logging
+                                  else if((pos = pmsg->find("> ")) != std::string::npos){
+                                      pmsg->erase(pos, 2);
+                                  }
+
+                                  if(!pmsg->empty())
+                                      spdlog::info(socket_.remote_endpoint().address().to_string()+" >> \n{}", *pmsg);
+                              }
+
+                              // Wait for more input
                               do_read();
                           }
                       });


### PR DESCRIPTION
Closes #37 
- Fixed `do_write()`'s `msg` param possibly being destroyed before it was used, leading to the buffer accessing invalid memory
- Fixed `do_read()` and `do_write()` being called an unnecessary amount of times, which I believe leaked asynchronous operations that would be waiting perpetually