### PR TITLE
Bug/camera init

### DIFF
--- a/src/camera/abstractcamera.cpp
+++ b/src/camera/abstractcamera.cpp
@@ -48,7 +48,7 @@ void AbstractCamera::update_state(StateVariables& state)
     {
         if(!do_connect())
         {
-            throw std::runtime_error("Camera filed to connect");
+            throw std::runtime_error("Camera failed to connect");
         }
     }
     m_connected = state.camera.connected;

--- a/src/camera/abstractcamera.cpp
+++ b/src/camera/abstractcamera.cpp
@@ -5,7 +5,6 @@
 
 AbstractCamera::AbstractCamera(StateVariables& state) : m_type(state.camera.type)
 {
-    update_state(state);
 }
 
 void AbstractCamera::enable_video_output() { m_video_output = true; }

--- a/src/camera/abstractcamera.cpp
+++ b/src/camera/abstractcamera.cpp
@@ -2,6 +2,7 @@
 #include "opencvcamera.h"
 #include "spinnakercamera.h"
 #include "../cmdhandler/constants/variables.h"
+#include <spdlog/spdlog.h>
 
 AbstractCamera::AbstractCamera(StateVariables& state) : m_type(state.camera.type)
 {
@@ -27,8 +28,9 @@ void AbstractCamera::update_state(StateVariables& state)
     if(m_connection_url != state.camera.url)
     {
         m_connection_url = state.camera.url;
-        // If the camera was connected while the URL was changed, reset the connection
-        if(is_connected())
+        // If the camera was connected while the URL was changed and the camera should continue to be connected,
+        // reset the connection
+        if(is_connected() && state.camera.connected)
         {
             do_disconnect();
             do_connect();
@@ -36,10 +38,18 @@ void AbstractCamera::update_state(StateVariables& state)
     }
 
     if(m_connected && !state.camera.connected)
+    {
         if(!do_disconnect())
+        {
             throw std::runtime_error("Camera failed to disconnect");
+        }
+    }
     else if(!m_connected && state.camera.connected)
+    {
         if(!do_connect())
+        {
             throw std::runtime_error("Camera filed to connect");
+        }
+    }
     m_connected = state.camera.connected;
 }

--- a/src/camera/abstractcamera.h
+++ b/src/camera/abstractcamera.h
@@ -8,6 +8,8 @@
 #include "../cmdhandler/statevariables.h"
 #include "cameracalib.h"
 
+// Abstract base class for all camera types
+// update_state() must be called immediately after object creation to ensure proper initialization
 class AbstractCamera : public UpdateableState
 {
 public:

--- a/src/camera/camerawrapper.cpp
+++ b/src/camera/camerawrapper.cpp
@@ -22,16 +22,20 @@ void CameraWrapper::update_state(StateVariables& state)
 
 std::unique_ptr<AbstractCamera> CameraWrapper::new_camera(StateVariables& state)
 {
+    std::unique_ptr<AbstractCamera> ptr;
     if(state.camera.type == CameraSystemVars::TYPE_OPENCV)
     {
-        return std::make_unique<OpenCvCamera>(state);
+        ptr = std::make_unique<OpenCvCamera>(state);
     }
     else if(state.camera.type == CameraSystemVars::TYPE_SPINNAKER)
     {
-        return std::make_unique<SpinnakerCamera>(state);
+        ptr = std::make_unique<SpinnakerCamera>(state);
     }
     else
     {
         throw std::runtime_error("Invalid camera type '" + state.camera.type + "'");
     }
+
+    ptr->update_state(state);
+    return ptr;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,9 +106,6 @@ void camera_thread_func(std::shared_ptr<GlobalState> state)
             // Apply any changes to state variables
             if(state->apply(local_variables))
             {
-                server.update_state(local_variables);
-                camera.update_state(local_variables);
-
                 if(!local_variables.camera.connected)
                 {
                     // Wait for camera to be connected and necessary properties present
@@ -118,6 +115,9 @@ void camera_thread_func(std::shared_ptr<GlobalState> state)
                                 });
                     state->apply(local_variables);
                 }
+
+                server.update_state(local_variables);
+                camera.update_state(local_variables);
             }
 
             if(camera->get_frame(frame))


### PR DESCRIPTION
closes #44  
- This fixes the bug in which the camera would not be properly initialized because of pure-virtual functions being called within the constructor of AbstractCamera
- This fixes incorrect chaining of if-elseif statements in AbstractCamera that was a result of not using curly braces
- This fixes a typo in the camera connection failure message in AbstractCamera