### PR TITLE
Add support for opencv device id connections

### DIFF
--- a/src/camera/opencvcamera.cpp
+++ b/src/camera/opencvcamera.cpp
@@ -1,4 +1,5 @@
 #include "opencvcamera.h"
+#include <charconv>
 
 OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
 {
@@ -6,7 +7,18 @@ OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
 
 bool OpenCvCamera::do_connect()
 {
-    return m_video_feed.open(get_connection_url());
+    // Get a local variable reference since we'll be using this string in several places
+    const std::string& connection_url = get_connection_url();
+    // Attempt to convert the string to an integer
+    int device_id;
+    const auto result = std::from_chars(connection_url.data(), connection_url.data() + connection_url.size(), device_id);
+
+    // If there is no error and at no point a non-integer character was encountered, use the integer value
+    if(result.ec == std::errc() && (result.ptr == (connection_url.data()+connection_url.size())))
+        return m_video_feed.open(device_id);
+    // Otherwise connect with the string
+    else
+        return m_video_feed.open(connection_url);
 }
 
 bool OpenCvCamera::do_disconnect()


### PR DESCRIPTION
closes #45 
- This adds the ability to connect to a device through opencv with a device id, i.e. '0'. This just checks if the given url string is actually an integer and, if it is, converts it to an int and uses that to connect. Otherwise it just connects with the given string like normal