### PR TITLE
Rename camera url to camera source

### DIFF
--- a/src/camera/abstractcamera.cpp
+++ b/src/camera/abstractcamera.cpp
@@ -16,7 +16,7 @@ void AbstractCamera::disable_video_postprocessing() { m_video_postprocessing = f
 bool AbstractCamera::video_postprocessing_enabled() { return m_video_postprocessing; }
 
 const CameraCalib& AbstractCamera::get_camera_calib() const { return m_calib; }
-const std::string& AbstractCamera::get_connection_url() const { return m_connection_url; }
+const std::string& AbstractCamera::get_source() const { return m_source; }
 const std::string& AbstractCamera::get_type() const { return m_type; }
 bool AbstractCamera::is_connected() const { return m_connected; }
 
@@ -25,10 +25,10 @@ void AbstractCamera::update_state(StateVariables& state)
     if(m_type != state.camera.type)
         throw std::runtime_error("Wrong camera type -- '" + m_type + "' != '" + state.camera.type + "'");
 
-    if(m_connection_url != state.camera.url)
+    if(m_source != state.camera.source)
     {
-        m_connection_url = state.camera.url;
-        // If the camera was connected while the URL was changed and the camera should continue to be connected,
+        m_source = state.camera.source;
+        // If the camera was connected while the source was changed and the camera should continue to be connected,
         // reset the connection
         if(is_connected() && state.camera.connected)
         {

--- a/src/camera/abstractcamera.h
+++ b/src/camera/abstractcamera.h
@@ -27,7 +27,7 @@ public:
     bool video_postprocessing_enabled();
 
     const CameraCalib& get_camera_calib() const;
-    const std::string& get_connection_url() const;
+    const std::string& get_source() const;
     const std::string& get_type() const;
     bool is_connected() const;
 
@@ -55,7 +55,7 @@ private:
     bool m_connected {false};
 
     CameraCalib m_calib;
-    std::string m_connection_url;
+    std::string m_source;
     const std::string m_type;
 };
 

--- a/src/camera/opencvcamera.cpp
+++ b/src/camera/opencvcamera.cpp
@@ -8,17 +8,17 @@ OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
 bool OpenCvCamera::do_connect()
 {
     // Get a local variable reference since we'll be using this string in several places
-    const std::string& connection_url = get_connection_url();
+    const std::string& source = get_source();
     // Attempt to convert the string to an integer
     int device_id;
-    const auto result = std::from_chars(connection_url.data(), connection_url.data() + connection_url.size(), device_id);
+    const auto result = std::from_chars(source.data(), source.data() + source.size(), device_id);
 
     // If there is no error and at no point a non-integer character was encountered, use the integer value
-    if(result.ec == std::errc() && (result.ptr == (connection_url.data()+connection_url.size())))
+    if(result.ec == std::errc() && (result.ptr == (source.data() + source.size())))
         return m_video_feed.open(device_id);
     // Otherwise connect with the string
     else
-        return m_video_feed.open(connection_url);
+        return m_video_feed.open(source);
 }
 
 bool OpenCvCamera::do_disconnect()

--- a/src/camera/opencvcamera.cpp
+++ b/src/camera/opencvcamera.cpp
@@ -1,4 +1,5 @@
 #include "opencvcamera.h"
+#include <charconv>
 
 OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
 {
@@ -6,7 +7,18 @@ OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
 
 bool OpenCvCamera::do_connect()
 {
-    return m_video_feed.open(get_connection_url());
+    // Get a local variable reference since we'll be using this string in several places
+    const std::string& connection_url = get_connection_url();
+    // Attempt to convert the string to an integer
+    int device_id;
+    const auto result = std::from_chars(connection_url.data(), connection_url.data() + connection_url.size(), device_id);
+
+    // If there is no error and at no point a non-integer character was encountered, use the integer value
+    if(result.ec == std::errc() && (result.ptr == (connection_url.data()+connection_url.size())))
+        return m_video_feed.open(device_id);
+    // Otherwise connect with the string
+    else
+        return m_video_feed.open(connection_url);
 }
 
 bool OpenCvCamera::do_disconnect()

--- a/src/camera/spinnakercamera.cpp
+++ b/src/camera/spinnakercamera.cpp
@@ -61,7 +61,7 @@ bool SpinnakerCamera::do_connect()
         if(Spinnaker::GenApi::IsAvailable(pserial) && Spinnaker::GenApi::IsReadable(pserial))
         {
             Spinnaker::GenICam::gcstring serial = pserial->GetValue();
-            if(serial == get_connection_url().c_str())
+            if(serial == get_source().c_str())
             {
                 m_pcam = pcam;
                 break;

--- a/src/cmdhandler/command_handler.cpp
+++ b/src/cmdhandler/command_handler.cpp
@@ -251,8 +251,8 @@ std::string command_handler::state_system(const std::vector<std::string>& tokens
         //save "connected" variable
         state_to_save.mutable_camera_system()->set_connected(current_state.camera.connected);
 
-        //save "url" string variable
-        state_to_save.mutable_camera_system()->set_url(current_state.camera.url);
+        //save "source" string variable
+        state_to_save.mutable_camera_system()->set_source(current_state.camera.source);
 
         //save "camera_matrix" cv::Mat
         cv::Mat camera_matrix = current_state.camera.camera_matrix;
@@ -324,8 +324,8 @@ std::string command_handler::state_system(const std::vector<std::string>& tokens
         //fill connected variable from loaded state
         current_state.camera.connected = state_to_load.camera_system().connected();
 
-        //fill url variable from loaded state
-        current_state.camera.url = state_to_load.camera_system().url();
+        //fill source variable from loaded state
+        current_state.camera.source = state_to_load.camera_system().source();
 
         //camera_matrix state variable, fill from loaded state
         std::vector<double> values;
@@ -496,8 +496,8 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
         //add connected variable
         response << "\n    " << CameraSystemVars::CONNECTED << ": " << std::boolalpha << current_state.camera.connected;
 
-        //add url variable
-        response << "\n    url: "+current_state.camera.url;
+        //add source variable
+        response << "\n    " << CameraSystemVars::SOURCE << ": " << current_state.camera.source;
 
         //add camera_matrix variable
         response << "\n    camera_matrix: ";
@@ -522,7 +522,7 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
         return response.str();
     }else if(tokens[0] == SET_CMD){
         if(tokens.size() < 3){
-            return "please provide a variable to set\n    ex: set camera url http://example.com";
+            return "please provide a variable to set\n    ex: set camera source http://example.com";
         }
 
         std::string variable = tokens[2];
@@ -566,12 +566,12 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
                 return "given value for variable +'"+variable+"' is not valid. acceptable values are 'true' and 'false'";
 
             return "camera "+variable+" set to '"+tokens[3]+"'";
-        }else if(variable == CameraSystemVars::URL){
+        }else if(variable == CameraSystemVars::SOURCE){
             if(tokens.size() != 4){
-                return "please provide a value for variable '"+variable+"'\n    ex: set camera url http://example.com";
+                return "please provide a value for variable '"+variable+"'\n    ex: set camera source http://example.com";
             }
-            current_state.camera.url = tokens[3];
-            return "camera url set to '"+tokens[3]+"'";
+            current_state.camera.source = tokens[3];
+            return "camera source set to '"+tokens[3]+"'";
         }else if(variable == CameraSystemVars::CAM_MATRIX || variable == CameraSystemVars::DIST_MATRIX){
             // since camera_matrix/distortion_matrix are the same data type/format, just use a conditional to assign a
             // cv::Mat to the chosen variable
@@ -640,7 +640,7 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
         return "variable '"+variable+"' does not exist";
     }else if(tokens[0] == GET_CMD){
         if(tokens.size() < 3){
-            return "please provide a variable to get\n    ex: get camera url";
+            return "please provide a variable to get\n    ex: get camera source";
         }
 
         std::string variable = tokens[2];
@@ -649,8 +649,8 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
             return variable + ": " + current_state.camera.type;
         }else if(variable == CameraSystemVars::CONNECTED){
             return variable+": " + (current_state.camera.connected ? "true" : "false");
-        }else if(variable == CameraSystemVars::URL){
-            return "url: "+current_state.camera.url;
+        }else if(variable == CameraSystemVars::SOURCE){
+            return variable+": "+current_state.camera.source;
         }else if(variable == CameraSystemVars::CAM_MATRIX || variable == CameraSystemVars::DIST_MATRIX) {
             std::stringstream response;
             response << variable << ": ";
@@ -681,14 +681,14 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
         return "variable '"+variable+"' does not exist";
     }else if(tokens[0] == DELETE_CMD){
         if(tokens.size() < 3){
-            return "please provide a variable to delete\n    ex: delete camera url";
+            return "please provide a variable to delete\n    ex: delete camera source";
         }
 
         std::string variable = tokens[2];
         current_state.camera = CameraSystem{};
 
-        if(variable == CameraSystemVars::URL){
-            current_state.camera.url = "";
+        if(variable == CameraSystemVars::SOURCE){
+            current_state.camera.source = "";
         }else if(variable == CameraSystemVars::CAM_MATRIX){
             current_state.camera.camera_matrix = cv::Mat::zeros(current_state.camera.camera_matrix.size(), current_state.camera.camera_matrix.type());;
         }else if(variable == CameraSystemVars::DIST_MATRIX){
@@ -732,8 +732,8 @@ std::string command_handler::help_command(){
     response += "for the 'camera' system you can use the commands:\n";
     response += "    get, set, list (current camera variables), delete\n";
     response += "you can modify the following variables:\n";
-    response += "    type, connected, url, camera_matrix, distortion_matrix, marker_dictionary, camera_options\n";
-    response += "ex: 'get camera url' or 'list camera' or 'set camera marker_dictionary 6' or 'delete camera url'\n\n";
+    response += "    type, connected, source, camera_matrix, distortion_matrix, marker_dictionary, camera_options\n";
+    response += "ex: 'get camera source' or 'list camera' or 'set camera marker_dictionary 6' or 'delete camera source'\n\n";
 
     response += "intended usage for each target system/variable will be clarified if used incorrectly.\n\n";
     return response;

--- a/src/cmdhandler/constants/variables.h
+++ b/src/cmdhandler/constants/variables.h
@@ -5,7 +5,7 @@ namespace CameraSystemVars
 {
     constexpr char TYPE[] = "type";
     constexpr char CONNECTED[] = "connected";
-    constexpr char URL[] = "url";
+    constexpr char SOURCE[] = "source";
     constexpr char CAM_MATRIX[] = "camera_matrix";
     constexpr char DIST_MATRIX[] = "distortion_matrix";
     constexpr char MARKER_DICT[] = "marker_dictionary";

--- a/src/cmdhandler/state.proto
+++ b/src/cmdhandler/state.proto
@@ -25,7 +25,7 @@ message CameraSys
 {
   string type = 1;
   bool connected = 2;
-  string url = 3;
+  string source = 3;
   repeated double camera_matrix = 4;
   repeated double distortion_matrix = 5;
   int32 marker_dictionary = 6;

--- a/src/cmdhandler/statevariables.h
+++ b/src/cmdhandler/statevariables.h
@@ -27,7 +27,7 @@ struct CameraSystem
 {
     std::string type;
     bool connected = false;
-    std::string url;
+    std::string source;
     cv::Mat camera_matrix;
     cv::Mat distortion_matrix;
     int marker_dictionary = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ void camera_thread_func(std::shared_ptr<GlobalState> state)
     // Wait for camera to be connected and necessary properties present
     state->wait([](const StateVariables& state)
                 {
-                    return state.camera.connected && !state.camera.type.empty() && !state.camera.url.empty();
+                    return state.camera.connected && !state.camera.type.empty() && !state.camera.source.empty();
                 });
 
     StateVariables local_variables;
@@ -111,7 +111,7 @@ void camera_thread_func(std::shared_ptr<GlobalState> state)
                     // Wait for camera to be connected and necessary properties present
                     state->wait([](const StateVariables& state)
                                 {
-                                    return state.camera.connected && !state.camera.type.empty() && !state.camera.url.empty();
+                                    return state.camera.connected && !state.camera.type.empty() && !state.camera.source.empty();
                                 });
                     state->apply(local_variables);
                 }


### PR DESCRIPTION
closes #33 
- This renames the "url" camera variable to "source" so that the variable name is more general (since url isn't applicable to the spinnaker camera, for example)

- [x] #49  should be reviewed and merged before reviewing this