### PR TITLE
Improved docs

### DIFF
--- a/src/camera/abstractcamera.cpp
+++ b/src/camera/abstractcamera.cpp
@@ -16,7 +16,7 @@ void AbstractCamera::disable_video_postprocessing() { m_video_postprocessing = f
 bool AbstractCamera::video_postprocessing_enabled() { return m_video_postprocessing; }
 
 const CameraCalib& AbstractCamera::get_camera_calib() const { return m_calib; }
-const std::string& AbstractCamera::get_connection_url() const { return m_connection_url; }
+const std::string& AbstractCamera::get_source() const { return m_source; }
 const std::string& AbstractCamera::get_type() const { return m_type; }
 bool AbstractCamera::is_connected() const { return m_connected; }
 
@@ -25,10 +25,10 @@ void AbstractCamera::update_state(StateVariables& state)
     if(m_type != state.camera.type)
         throw std::runtime_error("Wrong camera type -- '" + m_type + "' != '" + state.camera.type + "'");
 
-    if(m_connection_url != state.camera.url)
+    if(m_source != state.camera.source)
     {
-        m_connection_url = state.camera.url;
-        // If the camera was connected while the URL was changed and the camera should continue to be connected,
+        m_source = state.camera.source;
+        // If the camera was connected while the source was changed and the camera should continue to be connected,
         // reset the connection
         if(is_connected() && state.camera.connected)
         {

--- a/src/camera/abstractcamera.cpp
+++ b/src/camera/abstractcamera.cpp
@@ -4,7 +4,7 @@
 #include "../cmdhandler/constants/variables.h"
 #include <spdlog/spdlog.h>
 
-AbstractCamera::AbstractCamera(StateVariables& state) : m_type(state.camera.type)
+AbstractCamera::AbstractCamera(const StateVariables& state) : m_type(state.camera.type)
 {
 }
 
@@ -20,7 +20,7 @@ const std::string& AbstractCamera::get_source() const { return m_source; }
 const std::string& AbstractCamera::get_type() const { return m_type; }
 bool AbstractCamera::is_connected() const { return m_connected; }
 
-void AbstractCamera::update_state(StateVariables& state)
+void AbstractCamera::update_state(const StateVariables& state)
 {
     // Make sure that somehow this camera wasn't replaced with a new one during a type change
     if(m_type != state.camera.type)

--- a/src/camera/abstractcamera.cpp
+++ b/src/camera/abstractcamera.cpp
@@ -22,9 +22,11 @@ bool AbstractCamera::is_connected() const { return m_connected; }
 
 void AbstractCamera::update_state(StateVariables& state)
 {
+    // Make sure that somehow this camera wasn't replaced with a new one during a type change
     if(m_type != state.camera.type)
         throw std::runtime_error("Wrong camera type -- '" + m_type + "' != '" + state.camera.type + "'");
 
+    // if the camera source has changed
     if(m_source != state.camera.source)
     {
         m_source = state.camera.source;
@@ -37,6 +39,7 @@ void AbstractCamera::update_state(StateVariables& state)
         }
     }
 
+    // If the camera is connected and no longer should be, then disconnect
     if(m_connected && !state.camera.connected)
     {
         if(!do_disconnect())
@@ -44,6 +47,7 @@ void AbstractCamera::update_state(StateVariables& state)
             throw std::runtime_error("Camera failed to disconnect");
         }
     }
+    // If the camera is not connected and should be, then connect
     else if(!m_connected && state.camera.connected)
     {
         if(!do_connect())

--- a/src/camera/abstractcamera.h
+++ b/src/camera/abstractcamera.h
@@ -111,14 +111,14 @@ public:
      * @param state [in] State to update class members from
      * @throws std::runtime_error if this camera type is different than the camera type in the state
      */
-    void update_state(StateVariables& state) override;
+    void update_state(const StateVariables& state) override;
 
 protected:
     /** @brief Creates new AbstractCamera instance
      *
-     * @param state [in] Reference to state that this camera should get its parameters from
+     * @param state [in] Const reference to state that this camera should get its parameters from
      */
-    explicit AbstractCamera(StateVariables& state);
+    explicit AbstractCamera(const StateVariables& state);
 
     /** @brief Establish connection to the camera
      *

--- a/src/camera/abstractcamera.h
+++ b/src/camera/abstractcamera.h
@@ -27,7 +27,7 @@ public:
     bool video_postprocessing_enabled();
 
     const CameraCalib& get_camera_calib() const;
-    const std::string& get_connection_url() const;
+    const std::string& get_source() const;
     const std::string& get_type() const;
     bool is_connected() const;
 
@@ -55,7 +55,7 @@ private:
     bool m_connected {false};
 
     CameraCalib m_calib;
-    std::string m_connection_url;
+    std::string m_source;
     const std::string m_type;
 };
 

--- a/src/camera/abstractcamera.h
+++ b/src/camera/abstractcamera.h
@@ -97,8 +97,6 @@ public:
      */
     bool is_connected() const;
 
-    // Get a frame for processing from the camera
-    // Returns if frame was successfully retrieved
     /** @brief Get a frame from the camera
      *
      * This returns the most recent frame from the camera's video feed

--- a/src/camera/abstractcamera.h
+++ b/src/camera/abstractcamera.h
@@ -116,7 +116,7 @@ public:
 protected:
     /** @brief Creates new AbstractCamera instance
      *
-     * @param state [in] Const reference to state that this camera should get its parameters from
+     * @param state [in] State that this camera should get its configuration from
      */
     explicit AbstractCamera(const StateVariables& state);
 

--- a/src/camera/abstractcamera.h
+++ b/src/camera/abstractcamera.h
@@ -8,8 +8,12 @@
 #include "../cmdhandler/statevariables.h"
 #include "cameracalib.h"
 
-// Abstract base class for all camera types
-// update_state() must be called immediately after object creation to ensure proper initialization
+/** @brief Abstract base class for all camera types
+ *
+ * @note Use CameraWrapper to create a new camera. This class cannot be initialized directly, and derived classes should
+ *       not be either
+ * @note update_state() must be called immediately after object creation to ensure proper initialization
+ */
 class AbstractCamera : public UpdateableState
 {
 public:
@@ -17,36 +21,125 @@ public:
     // Don't allow copying since it would mess with connections
     AbstractCamera(AbstractCamera& other) = delete;
 
-    // Set if the camera's video feed should be available to clients
+    /** @brief Enable video output
+     *
+     * This enables the camera's video feed being displayed
+     *
+     * @see AbstractCamera::disable_video_output()
+     * @see AbstractCamera::video_output_enabled()
+     */
     void enable_video_output();
+
+    /** @brief Disable video output
+     *
+     * This disables the camera's video feed being displayed
+     *
+     * @see AbstractCamera::enable_video_output()
+     * @see AbstractCamera::video_output_enabled()
+     */
     void disable_video_output();
+
+    /** @brief The current status of video output
+     *
+     * @return True if video output is enabled, false if it is not
+     * @see AbstractCamera::enable_video_output()
+     * @see AbstractCamera::disable_video_output()
+     */
     bool video_output_enabled();
-    // Set if detected objects should be drawn to video feed before displaying to clients
+
+    /** @brief Enable video post processing
+     *
+     * This enables post processing to video output, such as drawing detected ArUco markers
+     *
+     * @note Video output must be enabled as well, see AbstractCamera::enable_video_output()
+     */
     void enable_video_postprocessing();
+
+    /** @brief Disable video post processing
+     *
+     * This disables post processing to video output, such as drawing detected ArUco markers
+     */
     void disable_video_postprocessing();
+
+    /** @brief The current status of video post processing
+     *
+     * @return True if video postprocessing is enabled, false if it is not
+     */
     bool video_postprocessing_enabled();
 
+    /** @brief Get the calibration parameters for the camera
+     *
+     * @return Calibration parameters for camera
+     * @see CameraCalib
+     */
     const CameraCalib& get_camera_calib() const;
+
+    /** @brief Get the connection source for the camera
+     *
+     * This returns the connection source for the camera; the source of the camera's video feed
+     *
+     * @return Camera's connection source as string
+     */
     const std::string& get_source() const;
+
+    /** @brief Get the camera type
+     *
+     * This returns the type of camera that this is; it signifies which of the derived classes that this camera uses
+     *
+     * @return Camera type as string
+     * @see CameraSystemVars::TYPES
+     */
     const std::string& get_type() const;
+
+    /** @brief Is the camera currently connected
+     *
+     * @return True if the camera is currently connected, false if it is not
+     */
     bool is_connected() const;
 
     // Get a frame for processing from the camera
     // Returns if frame was successfully retrieved
+    /** @brief Get a frame from the camera
+     *
+     * This returns the most recent frame from the camera's video feed
+     *
+     * @param frame [out] The frame that was retrieved as a cv::Mat
+     * @return True if the frame was successfully retrieved as a cv::Mat, false otherwise
+     */
     virtual bool get_frame(cv::Mat& frame)=0;
 
-    // Throws an exception if type of this camera is different than the type in the state
+    /** @brief Update camera class members from the given state
+     *
+     * @param state [in] State to update class members from
+     * @throws std::runtime_error if this camera type is different than the camera type in the state
+     */
     void update_state(StateVariables& state) override;
 
 protected:
+    /** @brief Creates new AbstractCamera instance
+     *
+     * @param state [in] Reference to state that this camera should get its parameters from
+     */
     explicit AbstractCamera(StateVariables& state);
-    // Establish a connection to the camera
-    // Return true if connection successful, false if connection was not successful
-    // This does not need to check if the camera is already connected or disconnected, that is handled elsewhere
+
+    /** @brief Establish connection to the camera
+     *
+     * This opens a new connection to the camera source
+     *
+     * @note This should not check if the camera is currently connected/disconnected as that is handled elsewhere
+     *
+     * @return True if the connection was successful, false otherwise
+     * @see AbstractCamera::do_disconnect()
+     */
     virtual bool do_connect()=0;
-    // Disconnect from the camera
-    // Return true if disconnect was successful, false if disconnect was not successful
-    // This does not need to check if the camera is already connected or disconnected, that is handled elsewhere
+
+    /** @brief Disconnect from the camera
+     *
+     * @note This should not check if the camera is currently connected/disconnected as that is handled elsewhere
+     *
+     * @return True if the disconnect was successful, false otherwise
+     * @see AbstractCamera::do_connect()
+     */
     virtual bool do_disconnect()=0;
 
 private:

--- a/src/camera/cameracalib.h
+++ b/src/camera/cameracalib.h
@@ -2,11 +2,15 @@
 #define MELON_CAMERACALIB_H
 
 #include <opencv2/core/mat.hpp>
+
+/** @brief Camera calibration parameters
+ *
+ */
 struct CameraCalib
 {
-    // Calibration matrix
+    /// Calibration matrix
     cv::Mat matrix;
-    // Distortion coefficients
+    /// Distortion coefficients
     cv::Mat dist_coeffs;
 };
 

--- a/src/camera/camerawrapper.cpp
+++ b/src/camera/camerawrapper.cpp
@@ -12,7 +12,7 @@ AbstractCamera* CameraWrapper::operator->() const noexcept
     return m_camera.get();
 }
 
-void CameraWrapper::update_state(StateVariables& state)
+void CameraWrapper::update_state(const StateVariables& state)
 {
     // If the camera type has changed, create a new camera of the new type
     if(m_camera->get_type() != state.camera.type)
@@ -22,7 +22,7 @@ void CameraWrapper::update_state(StateVariables& state)
         m_camera->update_state(state);
 }
 
-std::unique_ptr<AbstractCamera> CameraWrapper::new_camera(StateVariables& state)
+std::unique_ptr<AbstractCamera> CameraWrapper::new_camera(const StateVariables& state)
 {
     std::unique_ptr<AbstractCamera> ptr;
     if(state.camera.type == CameraSystemVars::TYPE_OPENCV)

--- a/src/camera/camerawrapper.cpp
+++ b/src/camera/camerawrapper.cpp
@@ -14,8 +14,10 @@ AbstractCamera* CameraWrapper::operator->() const noexcept
 
 void CameraWrapper::update_state(StateVariables& state)
 {
+    // If the camera type has changed, create a new camera of the new type
     if(m_camera->get_type() != state.camera.type)
         m_camera = new_camera(state);
+    // Otherwise, just update the state of the camera
     else
         m_camera->update_state(state);
 }

--- a/src/camera/camerawrapper.h
+++ b/src/camera/camerawrapper.h
@@ -4,24 +4,60 @@
 #include "abstractcamera.h"
 #include <memory>
 
+/** @brief Wrapper for initializing cameras
+ *
+ * This is a wrapper class for AbstractCamera and derivative classes. Internally it holds a smart pointer to an
+ * AbstractCamera. It's mainly for easily managing the multiple possible camera types
+ *
+ */
 class CameraWrapper : public UpdateableState
 {
 public:
-    // Throws an exception if camera type in variables is invalid
+     /** @brief Create a new CameraWrapper instance
+     *
+     * @param variables [in] Reference to current program state
+     * @throws std::runtime_error If camera type within current state is invalid
+     */
     explicit CameraWrapper(StateVariables& variables);
 
     // Gets the current camera instance
     // NOTE: DO NOT STORE THIS!! If this pointer is stored somewhere and the internal camera pointer changes,
     // this pointer will be invalidated!
     // NOTE: NOT THREAD SAFE
+    /** @brief Gets the current camera instance
+     *
+     * This performs a dereference to the internal AbstractCamera smart pointer, allowing functions and class members
+     * of AbstractCamera to "passthrough" without having getter function calls everywhere
+     *
+     * @note DO NOT STORE THE RETURNED POINTER. If this pointer is stored somewhere and the internal camera pointer
+     * changes (like in the event that the camera type changes) then the stored pointer will be invalidated
+     *
+     * @return Pointer to the internal AbstractCamera instance
+     */
     AbstractCamera* operator->() const noexcept;
 
     // Calls the wrapped camera's update_state implementation
+    /** @brief Update internal camera with current program state
+     *
+     * If the camera type in the state has changed, a new camera instance will be created.
+     * Otherwise AbstractCamera::update_state() is called for the internal camera
+     *
+     * @param state
+     */
     void update_state(StateVariables& state) override;
 
 private:
     std::unique_ptr<AbstractCamera> m_camera;
-    // Throws an exception if camera type in variables is invalid
+
+    /** @brief Create a new AbstractCamera instance
+     *
+     * This creates a new instance of an AbstractCamera derivative based on the current program state and casts it
+     * back into an AbstractCamera using a smart pointer
+     *
+     * @param state Current program state
+     * @return Smart pointer to AbstractCamera instance
+     * @throws std::runtime_error if camera type in state is invalid
+     */
     static std::unique_ptr<AbstractCamera> new_camera(StateVariables& state);
 };
 

--- a/src/camera/camerawrapper.h
+++ b/src/camera/camerawrapper.h
@@ -15,7 +15,7 @@ class CameraWrapper : public UpdateableState
 public:
      /** @brief Create a new CameraWrapper instance
      *
-     * @param variables [in] Reference to current program state
+     * @param variables [in] Current program state
      * @throws std::runtime_error If camera type within current state is invalid
      */
     explicit CameraWrapper(StateVariables& variables);

--- a/src/camera/camerawrapper.h
+++ b/src/camera/camerawrapper.h
@@ -44,7 +44,7 @@ public:
      *
      * @param state
      */
-    void update_state(StateVariables& state) override;
+    void update_state(const StateVariables& state) override;
 
 private:
     std::unique_ptr<AbstractCamera> m_camera;
@@ -58,7 +58,7 @@ private:
      * @return Smart pointer to AbstractCamera instance
      * @throws std::runtime_error if camera type in state is invalid
      */
-    static std::unique_ptr<AbstractCamera> new_camera(StateVariables& state);
+    static std::unique_ptr<AbstractCamera> new_camera(const StateVariables& state);
 };
 
 

--- a/src/camera/opencvcamera.cpp
+++ b/src/camera/opencvcamera.cpp
@@ -1,7 +1,7 @@
 #include "opencvcamera.h"
 #include <charconv>
 
-OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
+OpenCvCamera::OpenCvCamera(const StateVariables& state) : AbstractCamera(state)
 {
 }
 

--- a/src/camera/opencvcamera.cpp
+++ b/src/camera/opencvcamera.cpp
@@ -8,17 +8,17 @@ OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
 bool OpenCvCamera::do_connect()
 {
     // Get a local variable reference since we'll be using this string in several places
-    const std::string& connection_url = get_connection_url();
+    const std::string& source = get_source();
     // Attempt to convert the string to an integer
     int device_id;
-    const auto result = std::from_chars(connection_url.data(), connection_url.data() + connection_url.size(), device_id);
+    const auto result = std::from_chars(source.data(), source.data() + source.size(), device_id);
 
     // If there is no error and at no point a non-integer character was encountered, use the integer value
-    if(result.ec == std::errc() && (result.ptr == (connection_url.data()+connection_url.size())))
+    if(result.ec == std::errc() && (result.ptr == (source.data() + source.size())))
         return m_video_feed.open(device_id);
     // Otherwise connect with the string
     else
-        return m_video_feed.open(connection_url);
+        return m_video_feed.open(source);
 }
 
 bool OpenCvCamera::do_disconnect()

--- a/src/camera/opencvcamera.cpp
+++ b/src/camera/opencvcamera.cpp
@@ -1,4 +1,5 @@
 #include "opencvcamera.h"
+#include <charconv>
 
 OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
 {
@@ -6,7 +7,18 @@ OpenCvCamera::OpenCvCamera(StateVariables& state) : AbstractCamera(state)
 
 bool OpenCvCamera::do_connect()
 {
-    return m_video_feed.open(get_connection_url());
+    // Get a local variable reference since we'll be using this string in several places
+    const std::string& connection_url = get_connection_url();
+    // Attempt to convert the string to an integer
+    int device_id;
+    const auto result = std::from_chars(connection_url.data(), connection_url.data() + connection_url.size(), device_id);
+
+    // If there is no error and at no point a non-integer character was encountered, use the integer value
+    if(result.ec == std::errc() && (result.ptr == (connection_url.data()+connection_url.size())))
+        return m_video_feed.open(device_id);
+    // Otherwise connect with the string
+    else
+        return m_video_feed.open(connection_url);
 }
 
 bool OpenCvCamera::do_disconnect()

--- a/src/camera/opencvcamera.h
+++ b/src/camera/opencvcamera.h
@@ -3,7 +3,12 @@
 
 #include <opencv2/videoio.hpp>
 #include "abstractcamera.h"
-/// A camera compatible with OpenCV's "VideoCapture" class
+
+// A camera compatible with OpenCV's "VideoCapture" class
+/** @brief A camera that uses OpenCV's VideoCapture class
+ *
+ * This class is for camera's that are interfaced with using cv::VideoCapture
+ */
 class OpenCvCamera : public AbstractCamera
 {
 public:

--- a/src/camera/opencvcamera.h
+++ b/src/camera/opencvcamera.h
@@ -4,7 +4,6 @@
 #include <opencv2/videoio.hpp>
 #include "abstractcamera.h"
 
-// A camera compatible with OpenCV's "VideoCapture" class
 /** @brief A camera that uses OpenCV's VideoCapture class
  *
  * This class is for camera's that are interfaced with using cv::VideoCapture
@@ -12,7 +11,7 @@
 class OpenCvCamera : public AbstractCamera
 {
 public:
-    explicit OpenCvCamera(StateVariables& state);
+    explicit OpenCvCamera(const StateVariables& state);
 
     bool get_frame(cv::Mat& frame) override;
 

--- a/src/camera/spinnakercamera.cpp
+++ b/src/camera/spinnakercamera.cpp
@@ -61,7 +61,7 @@ bool SpinnakerCamera::do_connect()
         if(Spinnaker::GenApi::IsAvailable(pserial) && Spinnaker::GenApi::IsReadable(pserial))
         {
             Spinnaker::GenICam::gcstring serial = pserial->GetValue();
-            if(serial == get_connection_url().c_str())
+            if(serial == get_source().c_str())
             {
                 m_pcam = pcam;
                 break;

--- a/src/camera/spinnakercamera.cpp
+++ b/src/camera/spinnakercamera.cpp
@@ -71,8 +71,7 @@ bool SpinnakerCamera::do_connect()
 
     if(m_pcam == nullptr)
     {
-        // TODO: Insert serial number
-        spdlog::critical("Camera with serial number '{}' not found", "");
+        spdlog::critical("Camera with serial number '{}' not found", get_source());
         return false;
     }
 
@@ -90,7 +89,6 @@ bool SpinnakerCamera::do_connect()
     // Get camera nodes (settings)
     Spinnaker::GenApi::INodeMap& node_map = m_pcam->GetNodeMap();
 
-    // TODO: Check return type and do something if false
     // Enable "Continuous" mode so that an unspecified amount of frames can be read continuously
     if(!set_node_val(node_map, "AcquisitionMode", "Continuous"))
     {
@@ -103,9 +101,6 @@ bool SpinnakerCamera::do_connect()
         spdlog::error("Failed to set camera 'PixelFormat' to 'BGR8'");
         return false;
     }
-
-    // TODO: Disable heartbeat in debug? The example does this, but I'm not sure if it's referring to debugging
-    //      the hardware in some way or just having the executable compiled in debug mode
 
     // Start video capture
     m_pcam->BeginAcquisition();

--- a/src/camera/spinnakercamera.cpp
+++ b/src/camera/spinnakercamera.cpp
@@ -2,7 +2,7 @@
 #include <SpinGenApi/SpinnakerGenApi.h>
 #include <spdlog/spdlog.h>
 
-SpinnakerCamera::SpinnakerCamera(StateVariables& state) :
+SpinnakerCamera::SpinnakerCamera(const StateVariables& state) :
         AbstractCamera(state),
         m_psys(Spinnaker::System::GetInstance()),
         m_pcam(nullptr)

--- a/src/camera/spinnakercamera.h
+++ b/src/camera/spinnakercamera.h
@@ -4,7 +4,6 @@
 #include "abstractcamera.h"
 #include <Spinnaker.h>
 
-// A camera that uses Spinnaker SDK
 /** @brief A camera that uses Spinnaker SDK
  *
  * This class is for cameras that are interfaced with using Flir's Spinnaker SDK
@@ -12,7 +11,7 @@
 class SpinnakerCamera : public AbstractCamera
 {
 public:
-    explicit SpinnakerCamera(StateVariables& state);
+    explicit SpinnakerCamera(const StateVariables& state);
     ~SpinnakerCamera();
 
     bool get_frame(cv::Mat &frame) override;

--- a/src/camera/spinnakercamera.h
+++ b/src/camera/spinnakercamera.h
@@ -4,6 +4,11 @@
 #include "abstractcamera.h"
 #include <Spinnaker.h>
 
+// A camera that uses Spinnaker SDK
+/** @brief A camera that uses Spinnaker SDK
+ *
+ * This class is for cameras that are interfaced with using Flir's Spinnaker SDK
+ */
 class SpinnakerCamera : public AbstractCamera
 {
 public:

--- a/src/cmdhandler/command_handler.cpp
+++ b/src/cmdhandler/command_handler.cpp
@@ -95,15 +95,6 @@ std::string command_handler::build_matrix_string(const cv::Mat& matrix){
     return response.str();
 }
 
-/**
- * Modifies the 'robots' state variable. <br>
- * A robot has a name and a collection of 4 marker int ids. <br>
- * system functions: set, get, list, and delete robots
- *
- * @param tokens tokenized vector version of user command
- * @param current_state server's current state struct
- * @return response to user command as string
- */
 std::string command_handler::robot_system(const std::vector<std::string>& tokens, StateVariables& current_state){
     if(tokens[0] == LIST_CMD){
         std::string response = "Current robots:";
@@ -175,13 +166,6 @@ std::string command_handler::robot_system(const std::vector<std::string>& tokens
     }
 }
 
-/**
- * Saves and loads current state configurations to binary files in the 'states/' directory
- *
- * @param tokens tokenized vector version of user command
- * @param current_state server's current state struct
- * @return response to user command as string
- */
 std::string command_handler::state_system(const std::vector<std::string>& tokens, StateVariables& current_state){
     if(!std::filesystem::exists(StateSystemVars::SAVE_DIR)){
         std::error_code ec;
@@ -365,15 +349,6 @@ std::string command_handler::state_system(const std::vector<std::string>& tokens
     }
 }
 
-/**
- * Modifies the 'collectors' state variable. <br>
- * A collector has a name and an ip address associated with it, collectors receive data via udp from camera. <br>
- * system functions: set, get, list, and delete collectors
- *
- * @param tokens tokenized vector version of user command
- * @param current_state server's current state struct
- * @return response to user command as string
- */
 std::string command_handler::collector_system(const std::vector<std::string>& tokens, StateVariables& current_state) {
     if(tokens[0] == LIST_CMD){
         std::stringstream response;
@@ -450,14 +425,6 @@ std::string command_handler::collector_system(const std::vector<std::string>& to
     }
 }
 
-/**
- * Modifies variables in the 'CameraSystem' struct in 'Variables' class. <br>
- * system functions (on variables mentioned above): set, get, list, and delete
- *
- * @param tokens tokenized vector version of user command
- * @param current_state server's current state struct
- * @return response to user command as string
- */
 std::string command_handler::camera_system(const std::vector<std::string>& tokens, StateVariables& current_state){
     if(tokens[0] == LIST_CMD){
         std::stringstream response;
@@ -680,11 +647,6 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
     }
 }
 
-/**
- * Display available target systems/commands to user
- *
- * @return help string
- */
 std::string command_handler::help_command(){
     std::string response = "current target systems:\n";
     response += "    robot, state, collector, camera\n\n";

--- a/src/cmdhandler/command_handler.cpp
+++ b/src/cmdhandler/command_handler.cpp
@@ -25,13 +25,6 @@
 #include <sstream>
 #include <cctype>
 
-/**
- * Do a command by calling a specific target system depending on user command string.
- *
- * @param tokens tokenized vector version of user command
- * @param current_state server's current state struct
- * @return response to user command as string
- */
 std::string command_handler::do_command(const std::vector<std::string>& tokens, StateVariables& current_state){
     std::string command = tokens[0];
 
@@ -64,13 +57,6 @@ std::string command_handler::do_command(const std::vector<std::string>& tokens, 
     }
 }
 
-/**
- * Tokenize (split) a value string by commas. <br>
- * Used for when a target system takes a value parameter as a comma separated list.
- *
- * @param values value string to tokenize
- * @return a vector of strings
- */
 std::vector<std::string> command_handler::tokenize_values_by_commas(const std::string& values){
     std::vector<std::string> tokens;
 
@@ -87,13 +73,6 @@ std::vector<std::string> command_handler::tokenize_values_by_commas(const std::s
     return tokens;
 }
 
-/**
- * Send a vector<string> (doubles) to a cv::Mat. <br>
- * Can throw an error if a non double value is given (std::invalid_argument)
- *
- * @param values vector<string> of values to put in matrix
- * @return matrix of values given in 'values'
- */
 cv::Mat command_handler::values_by_comma_to_mat(const std::vector<std::string>& values, const int rows){
     std::vector<double> values_as_double;
     for(int i = 0; i < values.size(); i++){
@@ -103,12 +82,6 @@ cv::Mat command_handler::values_by_comma_to_mat(const std::vector<std::string>& 
     return return_mat.reshape(1,rows).clone();
 }
 
-/**
- * Build a "x,x,x,x," list based on a matrix's values
- *
- * @param matrix matrix with values to add to return string
- * @return string for server response
- */
 std::string command_handler::build_matrix_string(const cv::Mat& matrix){
     std::stringstream response;
 

--- a/src/cmdhandler/command_handler.cpp
+++ b/src/cmdhandler/command_handler.cpp
@@ -251,8 +251,8 @@ std::string command_handler::state_system(const std::vector<std::string>& tokens
         //save "connected" variable
         state_to_save.mutable_camera_system()->set_connected(current_state.camera.connected);
 
-        //save "url" string variable
-        state_to_save.mutable_camera_system()->set_url(current_state.camera.url);
+        //save "source" string variable
+        state_to_save.mutable_camera_system()->set_source(current_state.camera.source);
 
         //save "camera_matrix" cv::Mat
         cv::Mat camera_matrix = current_state.camera.camera_matrix;
@@ -324,8 +324,8 @@ std::string command_handler::state_system(const std::vector<std::string>& tokens
         //fill connected variable from loaded state
         current_state.camera.connected = state_to_load.camera_system().connected();
 
-        //fill url variable from loaded state
-        current_state.camera.url = state_to_load.camera_system().url();
+        //fill source variable from loaded state
+        current_state.camera.source = state_to_load.camera_system().source();
 
         //camera_matrix state variable, fill from loaded state
         std::vector<double> values;
@@ -496,8 +496,8 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
         //add connected variable
         response << "\n    " << CameraSystemVars::CONNECTED << ": " << std::boolalpha << current_state.camera.connected;
 
-        //add url variable
-        response << "\n    url: "+current_state.camera.url;
+        //add source variable
+        response << "\n    " << CameraSystemVars::SOURCE << ": " << current_state.camera.source;
 
         //add camera_matrix variable
         response << "\n    camera_matrix: ";
@@ -522,7 +522,7 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
         return response.str();
     }else if(tokens[0] == SET_CMD){
         if(tokens.size() < 3){
-            return "please provide a variable to set\n    ex: set camera url http://example.com";
+            return "please provide a variable to set\n    ex: set camera source http://example.com";
         }
 
         std::string variable = tokens[2];
@@ -566,12 +566,12 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
                 return "given value for variable +'"+variable+"' is not valid. acceptable values are 'true' and 'false'";
 
             return "camera "+variable+" set to '"+tokens[3]+"'";
-        }else if(variable == CameraSystemVars::URL){
+        }else if(variable == CameraSystemVars::SOURCE){
             if(tokens.size() != 4){
-                return "please provide a value for variable '"+variable+"'\n    ex: set camera url http://example.com";
+                return "please provide a value for variable '"+variable+"'\n    ex: set camera source http://example.com";
             }
-            current_state.camera.url = tokens[3];
-            return "camera url set to '"+tokens[3]+"'";
+            current_state.camera.source = tokens[3];
+            return "camera source set to '"+tokens[3]+"'";
         }else if(variable == CameraSystemVars::CAM_MATRIX || variable == CameraSystemVars::DIST_MATRIX){
             // since camera_matrix/distortion_matrix are the same data type/format, just use a conditional to assign a
             // cv::Mat to the chosen variable
@@ -640,7 +640,7 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
         return "variable '"+variable+"' does not exist";
     }else if(tokens[0] == GET_CMD){
         if(tokens.size() < 3){
-            return "please provide a variable to get\n    ex: get camera url";
+            return "please provide a variable to get\n    ex: get camera source";
         }
 
         std::string variable = tokens[2];
@@ -649,8 +649,8 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
             return variable + ": " + current_state.camera.type;
         }else if(variable == CameraSystemVars::CONNECTED){
             return variable+": " + (current_state.camera.connected ? "true" : "false");
-        }else if(variable == CameraSystemVars::URL){
-            return "url: "+current_state.camera.url;
+        }else if(variable == CameraSystemVars::SOURCE){
+            return variable+": "+current_state.camera.source;
         }else if(variable == CameraSystemVars::CAM_MATRIX || variable == CameraSystemVars::DIST_MATRIX) {
             std::stringstream response;
             response << variable << ": ";
@@ -681,14 +681,14 @@ std::string command_handler::camera_system(const std::vector<std::string>& token
         return "variable '"+variable+"' does not exist";
     }else if(tokens[0] == DELETE_CMD){
         if(tokens.size() < 3){
-            return "please provide a variable to delete\n    ex: delete camera url";
+            return "please provide a variable to delete\n    ex: delete camera source";
         }
 
         std::string variable = tokens[2];
         current_state.camera = CameraSystem{};
 
-        if(variable == CameraSystemVars::URL){
-            current_state.camera.url = "";
+        if(variable == CameraSystemVars::SOURCE){
+            current_state.camera.source = "";
         }else if(variable == CameraSystemVars::CAM_MATRIX){
             current_state.camera.camera_matrix = cv::Mat::zeros(current_state.camera.camera_matrix.size(), current_state.camera.camera_matrix.type());;
         }else if(variable == CameraSystemVars::DIST_MATRIX){
@@ -732,8 +732,8 @@ std::string command_handler::help_command(){
     response += "for the 'camera' system you can use the commands:\n";
     response += "    get, set, list (current camera variables), delete\n";
     response += "you can modify the following variables:\n";
-    response += "    type, connected, url, camera_matrix, distortion_matrix, marker_dictionary, camera_options\n";
-    response += "ex: 'get camera url' or 'list camera' or 'set camera marker_dictionary 6' or 'delete camera url'\n\n";
+    response += "    type, connected, source, camera_matrix, distortion_matrix, marker_dictionary, camera_options\n";
+    response += "ex: 'get camera source' or 'list camera' or 'set camera marker_dictionary 6' or 'delete camera source'\n\n";
 
     response += "intended usage for each target system/variable will be clarified if used incorrectly.\n\n";
     return response;

--- a/src/cmdhandler/command_handler.h
+++ b/src/cmdhandler/command_handler.h
@@ -1,7 +1,3 @@
-//
-// Created by tim on 2/27/21.
-//
-
 #ifndef MELON_COMMAND_HANDLER_H
 #define MELON_COMMAND_HANDLER_H
 
@@ -13,18 +9,60 @@
 #include "statevariables.h"
 #include "state.pb.h"
 
+/** @brief Command handler system
+ *
+ * This class handles the processing of string-based commands that control the current state of the program
+ */
 class command_handler {
 public:
+    /** @brief Execute the given command
+     *
+     * Given a command string that has been split into tokens, this executes the given command
+     *
+     * @param tokens [in] Tokenized command string (split into a std::vector by space delimiter)
+     * @param current_state [in] Reference to the current state of the program
+     * @return Response to the command as a string
+     */
     static std::string do_command(const std::vector<std::string>& tokens, StateVariables& current_state);
 private:
+
+    /** @brief Tokenize (split) a string using commas
+     *
+     * This tokenizes a string based on the comma character; it is used for splitting up a value that is a comma
+     * separated list
+     *
+     * @param values [in] String to tokenize
+     * @return std::vector of strings, where each index is an element of the comma separated list
+     */
+    static std::vector<std::string> tokenize_values_by_commas(const std::string& values);
+
+    /** @brief Convert std::vector of doubles to a cv::Mat
+     *
+     * This takes a std::vector of double values and converts it into a cv::Mat
+     *
+     * @param values [in] std::vector of double values that compose the matrix
+     * @param rows [in] Number of rows within the matrix
+     * @return Matrix of values as a cv::Mat
+     * @throws std::invalid_argument if a list element is a non-double
+     */
+    static cv::Mat values_by_comma_to_mat(const std::vector<std::string>& values, const int rows);
+
+    /** @brief Convert a cv::Mat to a comma separated list
+     *
+     * This takes a cv::Mat and converts it to a comma separated list in a string (i.e. "x,x,x,x,"
+     *
+     * @note Only matrix values are converted, any extra data such as number of rows/columns, etc. is lost
+     *
+     * @param matrix Matrix to convert
+     * @return std::string containing a comma separated list of matrix values
+     */
+    static std::string build_matrix_string(const cv::Mat& matrix);
+
     static std::string robot_system(const std::vector<std::string>& tokens, StateVariables& current_state);
     static std::string state_system(const std::vector<std::string>& tokens, StateVariables& current_state);
     static std::string collector_system(const std::vector<std::string>& tokens, StateVariables& current_state);
     static std::string camera_system(const std::vector<std::string>& tokens, StateVariables& current_state);
     static std::string help_command();
-    static std::vector<std::string> tokenize_values_by_commas(const std::string& values);
-    static cv::Mat values_by_comma_to_mat(const std::vector<std::string>& values, const int rows);
-    static std::string build_matrix_string(const cv::Mat& matrix);
 };
 
 

--- a/src/cmdhandler/command_handler.h
+++ b/src/cmdhandler/command_handler.h
@@ -20,7 +20,7 @@ public:
      * Given a command string that has been split into tokens, this executes the given command
      *
      * @param tokens [in] Tokenized command string (split into a std::vector by space delimiter)
-     * @param current_state [in] Reference to the current state of the program
+     * @param current_state [in] Current state of the program
      * @return Response to the command as a string
      */
     static std::string do_command(const std::vector<std::string>& tokens, StateVariables& current_state);
@@ -53,15 +53,69 @@ private:
      *
      * @note Only matrix values are converted, any extra data such as number of rows/columns, etc. is lost
      *
-     * @param matrix Matrix to convert
+     * @param matrix [in] Matrix to convert
      * @return std::string containing a comma separated list of matrix values
      */
     static std::string build_matrix_string(const cv::Mat& matrix);
 
+    /** @brief Modifies the robot state system
+     * 
+     * This modifies the state system that handles robots. A robot has a name and a collection of 4 marker int ids.
+     * 
+     * Applicable commands: set, get, list, delete
+     * 
+     * @param tokens [in] Tokenized user command as vector of strings
+     * @param current_state [in] Current program state
+     * @return std::string containing response to user command
+     * @see RobotSystem
+     */
     static std::string robot_system(const std::vector<std::string>& tokens, StateVariables& current_state);
+    
+    /** @brief Handles loading and saving of program state
+     * 
+     * This saves and loads (serializes and deserializes) current program state to binary files
+     * 
+     * Applicable commands: save, load, list, delete
+     * 
+     * @param tokens [in] Tokenized user command as vector of strings
+     * @param current_state [in] Current program state
+     * @return std::string containing response to user command
+     */
     static std::string state_system(const std::vector<std::string>& tokens, StateVariables& current_state);
+    
+    /** @brief Modifies the collectors state system
+     * 
+     * This modifies the state system that handles collectors and data distribution to collectors. <br>
+     * A collector is composed of a name, ip address, and port number. Collectors receive camera data via UDP packets
+     * 
+     * @note Applicable system commands: set, get, list, delete
+     * 
+     * @param tokens [in] Tokenized user command as vector of strings
+     * @param current_state [in] Current program state
+     * @return std::string containing response to user command
+     * @see CollectorSystem
+     */
     static std::string collector_system(const std::vector<std::string>& tokens, StateVariables& current_state);
+    
+    /** @brief Modifies the camera state system
+     * 
+     * This modifies the state system that handles the camera
+     * 
+     * Applicable commands: set, get, list, delete
+     * 
+     * @param tokens [in] Tokenized user command as vector of strings
+     * @param current_state [in] Current program state
+     * @return std::string containing response to user command
+     * @see CameraSystem
+     */
     static std::string camera_system(const std::vector<std::string>& tokens, StateVariables& current_state);
+    
+    /** @brief Get help message
+     * 
+     * This displays available target systems and commands (with examples)
+     * 
+     * @return std::string containing help message
+     */
     static std::string help_command();
 };
 

--- a/src/cmdhandler/constants/variables.h
+++ b/src/cmdhandler/constants/variables.h
@@ -5,7 +5,7 @@ namespace CameraSystemVars
 {
     constexpr char TYPE[] = "type";
     constexpr char CONNECTED[] = "connected";
-    constexpr char URL[] = "url";
+    constexpr char SOURCE[] = "source";
     constexpr char CAM_MATRIX[] = "camera_matrix";
     constexpr char DIST_MATRIX[] = "distortion_matrix";
     constexpr char MARKER_DICT[] = "marker_dictionary";

--- a/src/cmdhandler/globalstate.h
+++ b/src/cmdhandler/globalstate.h
@@ -47,7 +47,6 @@ public:
      */
     StateVariables get_state();
 
-    // Block current thread until the condition in func returns true
     /** @brief Wait until given callback function returns true
      *
      * This blocks the thread that this function is called within until the callback function returns true.

--- a/src/cmdhandler/globalstate.h
+++ b/src/cmdhandler/globalstate.h
@@ -28,7 +28,7 @@ public:
      *
      * @note The version of the incoming state is ignored
      *
-     * @param state [in] Const reference to the new program state
+     * @param state [in] The new program state
      */
     void receive(const StateVariables& state);
 

--- a/src/cmdhandler/globalstate.h
+++ b/src/cmdhandler/globalstate.h
@@ -7,19 +7,61 @@
 #include <condition_variable>
 #include <functional>
 
+/** @brief Global state manager for program
+ *
+ * This wraps a StateVariables instance so that it is thread-safe and can be used to update thread-local
+ * StateVariables instances
+ *
+ * @see StateVariables
+ */
 class GlobalState
 {
 public:
+    /** @brief Create a new instance
+     *
+     */
     GlobalState();
-    // Receive an update and integrate it into the global state. The version of the incoming state is ignored
+
+    /** @brief Update the global state
+     *
+     * This replaces the current internal global state with the given StateVariables
+     *
+     * @note The version of the incoming state is ignored
+     *
+     * @param state [in] Const reference to the new program state
+     */
     void receive(const StateVariables& state);
-    // Apply the global state to a local state, but only if necessary. Return whether
-    // global state was a newer version and update was applied
+
+    /** @brief Apply the global state to a thread-local state if necessary
+     *
+     * This applies the global state to the given thread-local state if the global state has a newer version number
+     *
+     * @param state [in, out] State to be updated
+     * @return If the state was updated (i.e. false if the version numbers were the same and no update was required)
+     */
     bool apply(StateVariables& state);
-    // Get a new local instance of the global state
+
+    /** @brief Get a copy of the global state
+     *
+     * @return Copy of the global state
+     */
     StateVariables get_state();
 
     // Block current thread until the condition in func returns true
+    /** @brief Wait until given callback function returns true
+     *
+     * This blocks the thread that this function is called within until the callback function returns true.
+     * The parameter in the callback function is a const reference to the global state.
+     * This callback function should return true if conditions are satisfied and waiting should be finished, and false
+     * otherwise.
+     * The main purpose of this function is so that a thread can be blocked until the global state contains desired
+     * variable values
+     *
+     * @note Don't forget to update any thread-local states and class instances that extent UpdateableState once
+     *       waiting is finished
+     *
+     * @param func Callback function determining if the thread should continue waiting
+     */
     void wait(const std::function<bool(const StateVariables&)>& func);
 private:
     StateVariables m_state;

--- a/src/cmdhandler/server.cpp
+++ b/src/cmdhandler/server.cpp
@@ -5,10 +5,6 @@ server::server(asio::io_context& io_context, short port, std::shared_ptr<GlobalS
     do_accept();
 }
 
-/**
- * Accept a new connection and make a shared pointer to a session instance. <br>
- * Then start the session and start reading/writing from/to tcp stream
- */
 void server::do_accept()
 {
     acceptor_.async_accept([this](asio::error_code ec, tcp::socket socket){

--- a/src/cmdhandler/server.h
+++ b/src/cmdhandler/server.h
@@ -7,11 +7,26 @@
 #include "globalstate.h"
 
 using asio::ip::tcp;
+/** @brief TCP server
+ *
+ * @see session
+ */
 class server{
 public:
+    /** Create new TCP server instance
+     *
+     * @param io_context [in] IO context to run on
+     * @param port [in] Port for server to run on
+     * @param state [in, out] Global state of the program to read from and write to
+     */
     server(asio::io_context& io_context, short port, std::shared_ptr<GlobalState> state);
 
 private:
+    /** @brief Accept new connection
+     *
+     * This accepts a new connection and makes a shared pointer to a new session instance. <br>
+     * This also then starts the session to begin reading/writing from/to the TCP stream
+     */
     void do_accept();
 
     tcp::acceptor acceptor_;

--- a/src/cmdhandler/session.cpp
+++ b/src/cmdhandler/session.cpp
@@ -42,7 +42,7 @@ void session::start()
     spdlog::info(socket_.remote_endpoint().address().to_string()+" connected");
     // Write out an initial '>' character so that user input stands out
     // do_write() also runs do_read(), so the program will begin listening after this is sent
-    do_write("> ", 2);
+    do_write("> ");
 }
 
 void session::do_read()
@@ -77,7 +77,7 @@ void session::do_read()
                                         }
                                         output << "> ";
                                         // Send the response
-                                        do_write(output.str(), output.str().length());
+                                        do_write(output.str());
                                     }else if(ec == asio::error::eof || ec == asio::error::connection_reset){
                                         spdlog::info(socket_.remote_endpoint().address().to_string()+" disconnected");
                                     }
@@ -91,11 +91,11 @@ void session::do_read()
  * @param msg message string to write out
  * @param length length of msg param
  */
-void session::do_write(std::string msg, std::size_t length)
+void session::do_write(std::string msg)
 {
     auto self(shared_from_this());
     std::shared_ptr<std::string> pmsg = std::make_shared<std::string>(msg);
-    asio::async_write(socket_, asio::buffer(pmsg->data(), length),
+    asio::async_write(socket_, asio::buffer(pmsg->data(), pmsg->length()),
                       [this, self, pmsg](asio::error_code ec, std::size_t length)
                       {
                           if (!ec)

--- a/src/cmdhandler/session.cpp
+++ b/src/cmdhandler/session.cpp
@@ -85,12 +85,6 @@ void session::do_read()
 
 }
 
-/**
- *  Write out to a connection (session) instance
- *
- * @param msg message string to write out
- * @param length length of msg param
- */
 void session::do_write(std::string msg)
 {
     auto self(shared_from_this());

--- a/src/cmdhandler/session.cpp
+++ b/src/cmdhandler/session.cpp
@@ -7,14 +7,7 @@ session::session(tcp::socket socket, std::shared_ptr<GlobalState> state): socket
 
 }
 
-/**
- * Read tcp stream until a new line character is present to build a command string
- *
- * @param data tcp stream to read
- * @param length length of data param
- * @return command obtained from user as a string
- */
-std::string session::get_command(char data[], std::size_t length){
+std::string session::get_command(const char data[], std::size_t length){
     std::string current_command;
     for (int i = 0; i < length; i++) {
         char c = data[i];
@@ -28,12 +21,6 @@ std::string session::get_command(char data[], std::size_t length){
     return current_command;
 }
 
-/**
- * Tokenize (split) a command string by spaces
- *
- * @param command string to tokenize
- * @return a vector of strings
- */
 std::vector<std::string> session::tokenize_command_by_spaces(std::string command){
     std::vector<std::string> tokens;
 
@@ -50,10 +37,6 @@ std::vector<std::string> session::tokenize_command_by_spaces(std::string command
     return tokens;
 }
 
-/**
- * Initialize a new connection. <br>
- * Will write out command prompt character and begin reading from connection.
- */
 void session::start()
 {
     spdlog::info(socket_.remote_endpoint().address().to_string()+" connected");
@@ -62,10 +45,6 @@ void session::start()
     do_write("> ", 2);
 }
 
-/**
- * Wait for and then read data from a connection (session) instance. <br>
- * Also return command handler's response to user.
- */
 void session::do_read()
 {
         auto self(shared_from_this());

--- a/src/cmdhandler/session.h
+++ b/src/cmdhandler/session.h
@@ -24,7 +24,7 @@ public:
     /** @brief Create a new session instance
      *
      * @param socket [in] Socket being used for the session
-     * @param state [in] Global state of the program
+     * @param state [in, out] Global state of the program to read from and write to
      */
     session(tcp::socket socket, std::shared_ptr<GlobalState> state);
 

--- a/src/cmdhandler/session.h
+++ b/src/cmdhandler/session.h
@@ -11,14 +11,25 @@
 #include "globalstate.h"
 
 using asio::ip::tcp;
+// Active connection session for a client in the command handler server
 class session : public std::enable_shared_from_this<session>
 {
 public:
+    // Create a new session instance
+    // Takes the socket for the session, and a smart pointer to the global state so that it can be updated
     session(tcp::socket socket, std::shared_ptr<GlobalState> state);
 
+    // Start the session
     void start();
 private:
+    // Read the tcp stream until a new line character is present in order to build a command string
+    // This returns the command obtained from the user as a string
+    // data is the tcp stream to read from
+    // length is the length of data
     std::string get_command(char data[], std::size_t length);
+    // This splits up a command string by spaces within the string
+    // This returns a vector of strings, where each index is a token
+    // Command is the string to tokenize
     std::vector<std::string> tokenize_command_by_spaces(std::string command);
 
     void do_read();

--- a/src/cmdhandler/session.h
+++ b/src/cmdhandler/session.h
@@ -11,29 +11,67 @@
 #include "globalstate.h"
 
 using asio::ip::tcp;
-// Active connection session for a client in the command handler server
+/** @brief Command handler connection session
+ *
+ * This is an active connection session for a client communicating with the command handler server
+ *
+ * @see server
+ * @see command_handler
+ */
 class session : public std::enable_shared_from_this<session>
 {
 public:
-    // Create a new session instance
-    // Takes the socket for the session, and a smart pointer to the global state so that it can be updated
+    /** @brief Create a new session instance
+     *
+     * @param socket [in] Socket being used for the session
+     * @param state [in] Global state of the program
+     */
     session(tcp::socket socket, std::shared_ptr<GlobalState> state);
 
-    // Start the session
+    /** @brief Start the session
+     *
+     * This initializes a new connection. It writes "> " to the user to have a more command-line-like interface and
+     * then begins reading from the connection
+     *
+     */
     void start();
 private:
-    // Read the tcp stream until a new line character is present in order to build a command string
-    // This returns the command obtained from the user as a string
-    // data is the tcp stream to read from
-    // length is the length of data
-    std::string get_command(char data[], std::size_t length);
-    // This splits up a command string by spaces within the string
-    // This returns a vector of strings, where each index is a token
-    // Command is the string to tokenize
+    /** @brief Read command from TCP stream
+     *
+     * This reads the TCP stream until a new-line character is present in order to build a command string
+     *
+     * @param data [in] TCP stream data
+     * @param length [in] Size of TCP stream data
+     * @return Command from user as std::string
+     */
+    std::string get_command(const char data[], std::size_t length);
+
+    /** @brief Tokenize (split) a command string by spaces
+     *
+     * This splits up a command string by spaces within the string
+     *
+     * @param command [in] String to tokenize
+     * @return std::vector of strings, where each index is a token
+     */
     std::vector<std::string> tokenize_command_by_spaces(std::string command);
 
+    /** @brief Read from the TCP stream
+     *
+     * This waits for and then reads data from a connection (session) instance and then returns the command handlers
+     * response to the user
+     *
+     * @see command_handler
+     * @see session::do_write()
+     */
     void do_read();
 
+    /** @brief Write to TCP stream
+     *
+     * This writes data to the connection (session) instance
+     *
+     * @param msg [in] Message string to write out
+     * @param length [in] Size of message
+     */
     void do_write(std::string msg, std::size_t length);
 
     tcp::socket socket_;

--- a/src/cmdhandler/session.h
+++ b/src/cmdhandler/session.h
@@ -72,7 +72,7 @@ private:
      * @param msg [in] Message string to write out
      * @param length [in] Size of message
      */
-    void do_write(std::string msg, std::size_t length);
+    void do_write(std::string msg);
 
     tcp::socket socket_;
     enum { max_length = 1024 };

--- a/src/cmdhandler/state.proto
+++ b/src/cmdhandler/state.proto
@@ -25,7 +25,7 @@ message CameraSys
 {
   string type = 1;
   bool connected = 2;
-  string url = 3;
+  string source = 3;
   repeated double camera_matrix = 4;
   repeated double distortion_matrix = 5;
   int32 marker_dictionary = 6;

--- a/src/cmdhandler/statevariables.h
+++ b/src/cmdhandler/statevariables.h
@@ -9,16 +9,25 @@
 #include <asio.hpp>
 #include <asio/ip/udp.hpp>
 
+/** @brief Robot system state
+ *
+ */
 struct RobotSystem
 {
     std::unordered_map<std::string, std::vector<int>> robots;
 };
 
+/** @brief Collector system state
+ *
+ */
 struct CollectorSystem
 {
     std::unordered_map<std::string, asio::ip::udp::endpoint> collectors;
 };
 
+/** @brief camera system state
+ *
+ */
 struct CameraSystem
 {
     std::string type;
@@ -30,6 +39,14 @@ struct CameraSystem
     std::unordered_map<std::string, bool> camera_options;
 };
 
+/** @brief Container class for state variables
+ *
+ * This is a container class for state variables to be extended by StateVariables. StateVariables
+ * requires a custom copy constructor because of atomic version number, so extending this class means all of the
+ * variables don't need to be manually added to the copy constructor
+ *
+ * @see StateVariables
+ */
 class Variables
 {
 public:
@@ -40,6 +57,9 @@ protected:
     Variables() = default;
 };
 
+/** @brief Variables for the system state
+ *
+ */
 class StateVariables : public Variables
 {
 public:
@@ -69,7 +89,7 @@ class UpdateableState
 public:
     /** @brief Update the class instance to coincide with the program's current state
      *
-     * @param state [in] Const reference to program state to update from
+     * @param state [in] Program state to update from
      */
     virtual void update_state(const StateVariables& state)=0;
 };

--- a/src/cmdhandler/statevariables.h
+++ b/src/cmdhandler/statevariables.h
@@ -27,7 +27,7 @@ struct CameraSystem
 {
     std::string type;
     bool connected = false;
-    std::string url;
+    std::string source;
     cv::Mat camera_matrix;
     cv::Mat distortion_matrix;
     int marker_dictionary = 0;

--- a/src/cmdhandler/statevariables.h
+++ b/src/cmdhandler/statevariables.h
@@ -1,7 +1,3 @@
-//
-// Created by tim on 2/27/21.
-//
-
 #ifndef MELON_STATEVARIABLES_H
 #define MELON_STATEVARIABLES_H
 
@@ -62,9 +58,19 @@ public:
     std::atomic_uint version;
 };
 
+/** @brief Classes that can be updated alongside a state change
+ *
+ * This is a pure-virtual abstract base class that classes can implement to signify that their internal state
+ * can change alongside a system state change (you can call ::update_state() on the object to update it instead of
+ * creating a new instance)
+ */
 class UpdateableState
 {
 public:
+    /** @brief Update the class instance to coincide with the program's current state
+     *
+     * @param state [in] Const reference to program state to update from
+     */
     virtual void update_state(StateVariables& state)=0;
 };
 

--- a/src/cmdhandler/statevariables.h
+++ b/src/cmdhandler/statevariables.h
@@ -71,7 +71,7 @@ public:
      *
      * @param state [in] Const reference to program state to update from
      */
-    virtual void update_state(StateVariables& state)=0;
+    virtual void update_state(const StateVariables& state)=0;
 };
 
 #endif //MELON_STATEVARIABLES_H

--- a/src/collectorserver/collectorserver.cpp
+++ b/src/collectorserver/collectorserver.cpp
@@ -16,12 +16,13 @@ CollectorServer::~CollectorServer()
 
 void CollectorServer::send(const std::string& data)
 {
+    // Assemble the message
     std::stringstream ss;
-
     ss << "{\"num\": \"" << m_message_count++ << "\", \"data\": \"" << data << "\"}";
     std::string message = ss.str();
     spdlog::info("Sending message to endpoints. Message: {}", message);
 
+    // Send the message to each collector
     for(auto& endpoint : m_endpoints)
     {
         std::stringstream ss;
@@ -38,6 +39,7 @@ void CollectorServer::send(const std::string& data)
 
 void CollectorServer::update_state(StateVariables& state)
 {
+    // Reset and refill the collectors
     m_endpoints.clear();
     m_endpoints.reserve(state.collector.collectors.size());
     for(auto& pair: state.collector.collectors)

--- a/src/collectorserver/collectorserver.cpp
+++ b/src/collectorserver/collectorserver.cpp
@@ -37,7 +37,7 @@ void CollectorServer::send(const std::string& data)
     spdlog::info("Message sent to all endpoints");
 }
 
-void CollectorServer::update_state(StateVariables& state)
+void CollectorServer::update_state(const StateVariables& state)
 {
     // Reset and refill the collectors
     m_endpoints.clear();

--- a/src/collectorserver/collectorserver.cpp
+++ b/src/collectorserver/collectorserver.cpp
@@ -2,7 +2,7 @@
 #include <spdlog/spdlog.h>
 #include <sstream>
 
-CollectorServer::CollectorServer(StateVariables& state) : m_socket(m_service), m_message_count(0)
+CollectorServer::CollectorServer(const StateVariables& state) : m_socket(m_service), m_message_count(0)
 {
     m_socket.open(asio::ip::udp::v4());
     update_state(state);

--- a/src/collectorserver/collectorserver.h
+++ b/src/collectorserver/collectorserver.h
@@ -4,11 +4,15 @@
 #include <asio.hpp>
 #include "../cmdhandler/statevariables.h"
 
+// Server for sending data from the camera to "collectors"
+// Collectors are given through the command handler system; each collector is a target ip address and port number
+// that data should be sent to
 class CollectorServer : public UpdateableState
 {
 public:
     CollectorServer(StateVariables& state);
     ~CollectorServer();
+    // Send the given data to all collectors
     void send(const std::string& data);
 
     void update_state(StateVariables& state) override;

--- a/src/collectorserver/collectorserver.h
+++ b/src/collectorserver/collectorserver.h
@@ -15,7 +15,7 @@ public:
     // Send the given data to all collectors
     void send(const std::string& data);
 
-    void update_state(StateVariables& state) override;
+    void update_state(const StateVariables& state) override;
 private:
     asio::io_service m_service;
     asio::ip::udp::socket m_socket;

--- a/src/collectorserver/collectorserver.h
+++ b/src/collectorserver/collectorserver.h
@@ -4,15 +4,31 @@
 #include <asio.hpp>
 #include "../cmdhandler/statevariables.h"
 
-// Server for sending data from the camera to "collectors"
-// Collectors are given through the command handler system; each collector is a target ip address and port number
-// that data should be sent to
+/** @brief Server for sending camera data to collectors
+ *
+ * This is a server for sending data processed from the camera to end-users specified within the collectors system. <br>
+ * Collectors are given through the command handler system; each collector is a target ip address and port number
+ * that data should be sent to
+ *
+ * @see command_handler
+ */
 class CollectorServer : public UpdateableState
 {
 public:
-    CollectorServer(StateVariables& state);
+    /** @brief Create new server instance
+     *
+     * @param state [in] State to receive configuration from
+     */
+    CollectorServer(const StateVariables& state);
     ~CollectorServer();
+
     // Send the given data to all collectors
+    /** @brief Send data to collectors
+     *
+     * This sends the given data string to all of the endpoints within the collector system
+     *
+     * @param data [in] Data to send
+     */
     void send(const std::string& data);
 
     void update_state(const StateVariables& state) override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ void camera_thread_func(std::shared_ptr<GlobalState> state)
     // Wait for camera to be connected and necessary properties present
     state->wait([](const StateVariables& state)
                 {
-                    return state.camera.connected && !state.camera.type.empty() && !state.camera.url.empty();
+                    return state.camera.connected && !state.camera.type.empty() && !state.camera.source.empty();
                 });
 
     StateVariables local_variables;
@@ -111,7 +111,7 @@ void camera_thread_func(std::shared_ptr<GlobalState> state)
                     // Wait for camera to be connected and necessary properties present
                     state->wait([](const StateVariables& state)
                                 {
-                                    return state.camera.connected && !state.camera.type.empty() && !state.camera.url.empty();
+                                    return state.camera.connected && !state.camera.type.empty() && !state.camera.source.empty();
                                 });
                     state->apply(local_variables);
                 }


### PR DESCRIPTION
closes #11
- This adds more documentation to the entire project and refactors any existing documentation to be in the "java-doc" style
- This also contains a couple small changes that didn't necessarily warrant its own issue/PR
    - Some small changes to logging messages (such as being slightly more descriptive and/or a new line character being added)
    - `UpdateableState::update_state()` now takes a const reference
    - Class constructors that accept a `StateVariables` instance for configuration now also take a const reference to the state
    - Remove an unnecessary `length` parameter from `session::do_write`, since we can just call `msg->length()` to get the string length

- [x] #50  should be reviewed and merged before reviewing this